### PR TITLE
careers.html footer fix

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -8,9 +8,58 @@
     <link href="https://fonts.googleapis.com/css?family=Lato&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.3.1/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.10.0-11/css/all.min.css">
-    <link rel="stylesheet" href="styles/footer.css">
     <link rel="stylesheet" href="styles/careers.css">
 
+    <style>
+    #footer {
+        background: #6D9BF1;
+          margin-top: 32%;  /* YOU CAN PULL THIS OUT WHEN YOU IMPLEMENT YOUR PAGE.*/
+          padding-top: 10px;
+          /* height: 300px; */
+          width: 100%;
+        }
+    
+        .links {
+          padding-top: 5px;
+        }
+        .social-links h3 {
+      font-size: 1rem;
+      line-height: 1.5;
+    }
+        .social-links h3,
+        .quick-links li {
+          list-style-type: none;
+          padding-top: 5px;
+        }
+    
+        .social-links h3,
+        .quick-links li:first-child {
+          color: #ffffff;
+          padding-bottom: 10px;
+          font-weight: bold;
+        }
+    
+        .quick-links li a {
+          color: #ffffff;
+          text-decoration: none;
+        }
+    
+        .social-links a span {
+          color: #ffffff;
+          letter-spacing: 20px;
+        }
+    
+        .social-links p,
+        .copyright p {
+          padding-top: 10px;
+          color: #ffffff;
+          font-size: 12px; 
+        }
+    
+        .line{
+          display: none;
+        }
+      </style>
     <title>Careers </title>
 </head>
 

--- a/styles/careers.css
+++ b/styles/careers.css
@@ -71,7 +71,7 @@ main .container{
     font-size: 20px;
 }
 .jobs{
-    margin: 50px 0;
+    margin: 50px 0 0 0;
 }
 .jobs h2{
     font-family: 'Lato', sans-serif;
@@ -81,7 +81,6 @@ main .container{
 }
 .jobs p{
     margin-top: 20px;
-    margin-bottom: 50px;
     font-family: 'Lato', sans-serif;
     font-style: normal;
     font-weight: 300;


### PR DESCRIPTION
took the styles for the footer from index.css and applied them as internal styles for the footer in careers.html. Proposing to do this for other pages because just copying and pasting the footer isn't providing the styles and using index.css might clash with other styles.